### PR TITLE
Phase 1: align infra with code (TTL, channel GSI, runtime 22, memory)

### DIFF
--- a/__tests__/services/datastore.test.js
+++ b/__tests__/services/datastore.test.js
@@ -25,14 +25,18 @@ jest.mock('@aws-sdk/lib-dynamodb', () => ({
     ScanCommand: jest.fn()
 }));
 
-const { 
-    getData, 
-    saveData, 
-    getPlayer, 
-    savePlayer, 
-    getDraft, 
-    saveDraft 
+const {
+    getData,
+    saveData,
+    getPlayer,
+    savePlayer,
+    getDraft,
+    saveDraft,
+    getDraftsByChannel,
+    getLeaguesByChannel
 } = require('../../services/datastore.js');
+
+const { QueryCommand, ScanCommand } = require('@aws-sdk/lib-dynamodb');
 
 describe('DynamoDB Datastore Service', () => {
 
@@ -220,6 +224,72 @@ describe('DynamoDB Datastore Service', () => {
             await saveDraft('67890', 'C123456', 25);
 
             expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('getDraftsByChannel', () => {
+        it('should query the SlackChannelIndex GSI scoped to DRAFT items', async () => {
+            mockSend.mockResolvedValue({
+                Items: [
+                    { draftId: '67890', slackChannelId: 'C123456', lastKnownPickCount: 10 }
+                ]
+            });
+
+            const result = await getDraftsByChannel('C123456');
+
+            expect(QueryCommand).toHaveBeenCalledWith(expect.objectContaining({
+                IndexName: 'SlackChannelIndex',
+                KeyConditionExpression: 'slackChannelId = :channelId AND PK = :pk',
+                ExpressionAttributeValues: { ':channelId': 'C123456', ':pk': 'DRAFT' }
+            }));
+            expect(result).toEqual([
+                { draftId: '67890', slack_channel_id: 'C123456', last_known_pick_count: 10 }
+            ]);
+        });
+
+        it('should fall back to a scan when the GSI is unavailable', async () => {
+            mockSend
+                .mockRejectedValueOnce(new Error('GSI not found'))
+                .mockResolvedValueOnce({
+                    Items: [
+                        { draftId: '111', slackChannelId: 'C999', lastKnownPickCount: 3 }
+                    ]
+                });
+
+            const result = await getDraftsByChannel('C999');
+
+            expect(ScanCommand).toHaveBeenCalled();
+            expect(result).toEqual([
+                { draftId: '111', slack_channel_id: 'C999', last_known_pick_count: 3 }
+            ]);
+        });
+    });
+
+    describe('getLeaguesByChannel', () => {
+        it('should query the SlackChannelIndex GSI scoped to LEAGUE items', async () => {
+            const items = [{ PK: 'LEAGUE', leagueId: 'L1', slackChannelId: 'C123456' }];
+            mockSend.mockResolvedValue({ Items: items });
+
+            const result = await getLeaguesByChannel('C123456');
+
+            expect(QueryCommand).toHaveBeenCalledWith(expect.objectContaining({
+                IndexName: 'SlackChannelIndex',
+                KeyConditionExpression: 'slackChannelId = :channelId AND PK = :pk',
+                ExpressionAttributeValues: { ':channelId': 'C123456', ':pk': 'LEAGUE' }
+            }));
+            expect(result).toEqual(items);
+        });
+
+        it('should fall back to a scan when the GSI is unavailable', async () => {
+            const items = [{ PK: 'LEAGUE', leagueId: 'L2', slackChannelId: 'C999' }];
+            mockSend
+                .mockRejectedValueOnce(new Error('GSI not found'))
+                .mockResolvedValueOnce({ Items: items });
+
+            const result = await getLeaguesByChannel('C999');
+
+            expect(ScanCommand).toHaveBeenCalled();
+            expect(result).toEqual(items);
         });
     });
 });

--- a/services/datastore.js
+++ b/services/datastore.js
@@ -219,15 +219,19 @@ async function saveDraft(draftId, slackChannelId, lastKnownPickCount = 0) {
  */
 async function getDraftsByChannel(slackChannelId) {
     try {
+        // SlackChannelIndex is a composite GSI (slackChannelId HASH + PK RANGE),
+        // so we filter to DRAFT items on the key itself — leagues share the
+        // slackChannelId attribute and would otherwise be returned too.
         const command = new QueryCommand({
             TableName: TABLE_NAME,
-            IndexName: 'SlackChannelIndex', // This would need to be created as a GSI
-            KeyConditionExpression: 'slackChannelId = :channelId',
+            IndexName: 'SlackChannelIndex',
+            KeyConditionExpression: 'slackChannelId = :channelId AND PK = :pk',
             ExpressionAttributeValues: {
-                ':channelId': slackChannelId
+                ':channelId': slackChannelId,
+                ':pk': 'DRAFT'
             }
         });
-        
+
         const response = await docClient.send(command);
         return response.Items.map(item => ({
             draftId: item.draftId,
@@ -393,6 +397,33 @@ async function getLeague(leagueId) {
  */
 async function getLeaguesByChannel(channelId) {
     try {
+        const command = new QueryCommand({
+            TableName: TABLE_NAME,
+            IndexName: 'SlackChannelIndex',
+            KeyConditionExpression: 'slackChannelId = :channelId AND PK = :pk',
+            ExpressionAttributeValues: {
+                ':channelId': channelId,
+                ':pk': 'LEAGUE'
+            }
+        });
+
+        const response = await docClient.send(command);
+        return response.Items || [];
+    } catch (error) {
+        // If GSI doesn't exist, fall back to scan (less efficient)
+        console.warn("GSI not available for leagues, falling back to scan:", error.message);
+        return await getLeaguesByChannelScan(channelId);
+    }
+}
+
+/**
+ * Fallback method to get leagues by channel using scan.
+ * @param {string} channelId The Slack channel ID.
+ * @returns {Promise<object[]>} Array of league objects registered to the channel.
+ * @throws {Error} if the leagues cannot be retrieved.
+ */
+async function getLeaguesByChannelScan(channelId) {
+    try {
         const scanCommand = new ScanCommand({
             TableName: TABLE_NAME,
             FilterExpression: 'PK = :pk AND slackChannelId = :channelId',
@@ -401,7 +432,7 @@ async function getLeaguesByChannel(channelId) {
                 ':channelId': channelId
             }
         });
-        
+
         const response = await docClient.send(scanCommand);
         return response.Items || [];
     } catch (error) {

--- a/template.yaml
+++ b/template.yaml
@@ -21,7 +21,7 @@ Parameters:
 
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
     Timeout: 30
     MemorySize: 256
     Environment:
@@ -43,11 +43,28 @@ Resources:
           AttributeType: S
         - AttributeName: SK
           AttributeType: S
+        - AttributeName: slackChannelId
+          AttributeType: S
       KeySchema:
         - AttributeName: PK
           KeyType: HASH
         - AttributeName: SK
           KeyType: RANGE
+      # Index channel-scoped lookups (drafts and leagues) so they Query by
+      # slackChannelId + item type (PK) instead of scanning the whole table.
+      GlobalSecondaryIndexes:
+        - IndexName: SlackChannelIndex
+          KeySchema:
+            - AttributeName: slackChannelId
+              KeyType: HASH
+            - AttributeName: PK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      # Auto-expire items carrying a `ttl` epoch attribute (e.g. event dedup records).
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:
@@ -66,6 +83,9 @@ Resources:
       CodeUri: ./
       Handler: lambda-handler.handler
       Description: 'UKFF Slack Bot for Fantasy Football Draft Management'
+      # More memory (and proportional CPU) keeps cold-start init within the
+      # interactive Slack request budget. The scheduled functions inherit 256.
+      MemorySize: 512
       Environment:
         Variables:
           NODE_ENV: production


### PR DESCRIPTION
First PR of the architecture hardening plan (see docs/ARCHITECTURE_PLAN.md). Aligns the deployed infrastructure with what the code already assumes. No user-facing behavior change.

## Changes

### Infrastructure (`template.yaml`)
- **Enable DynamoDB TTL** on the `ttl` attribute. Event-dedup records (`lambda-handler.js`) set a `ttl` but the table never had TTL enabled, so they accumulated forever. Now they auto-expire.
- **Add the `SlackChannelIndex` GSI** that the code already queries (`datastore.js`) and silently falls back to a full-table `Scan` for. Made it a **composite key** (`slackChannelId` HASH + `PK` RANGE) rather than `slackChannelId`-only, because **both DRAFT and LEAGUE items carry `slackChannelId`** — a HASH-only index would return leagues from the drafts query and mis-map them. The composite key lets each lookup Query by channel + item type directly.
- **Runtime `nodejs20.x` → `nodejs22.x`** to match `package.json` engines (`>=22`) and CI.
- **Slack handler memory 256MB → 512MB** (more CPU for cold-start init within the interactive Slack request budget). Scheduled functions stay at 256MB.

### Datastore (`services/datastore.js`)
- `getDraftsByChannel`: query the GSI with `slackChannelId = :c AND PK = 'DRAFT'`.
- `getLeaguesByChannel`: switch from a full-table `Scan` to the same GSI query (`PK = 'LEAGUE'`), with a `Scan` fallback mirroring the drafts path. This also removes the scheduled roster check's full-table scan.

### Tests
- Added coverage for both channel-query functions (GSI path + scan fallback). Suite: 83 passing.

## Deploy notes
- Adding a GSI + enabling TTL on the existing table are **online** operations; CloudFormation completes once the GSI finishes backfilling. The code's scan fallbacks keep channel lookups working throughout.
- After deploy, confirm the `SlackChannelIndex` GSI shows ACTIVE and TTL is enabled on the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)