### PR TITLE
Phase 2: resilient API calls + graceful roster-analysis degradation

### DIFF
--- a/__tests__/services/rosterAnalyzer.degradation.test.js
+++ b/__tests__/services/rosterAnalyzer.degradation.test.js
@@ -1,0 +1,67 @@
+// Verifies analyzeLeagueRosters degrades gracefully when non-essential upstream
+// data fails to load, and still fails fast when rosters themselves are missing.
+jest.mock('../../services/sleeper.js');
+jest.mock('../../services/nflDataCache.js');
+
+const sleeper = require('../../services/sleeper.js');
+const cache = require('../../services/nflDataCache.js');
+const { analyzeLeagueRosters } = require('../../services/rosterAnalyzer.js');
+
+describe('analyzeLeagueRosters graceful degradation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        sleeper.getLeague.mockResolvedValue({
+            league_id: 'L1', name: 'Test League', season: 2025, roster_positions: ['QB', 'RB']
+        });
+        sleeper.getNflState.mockResolvedValue({ season: '2025', week: 5, display_week: 5 });
+        sleeper.getLeagueRosters.mockResolvedValue([
+            { roster_id: 1, owner_id: 'U1', starters: ['p1'], players: ['p1'] }
+        ]);
+        sleeper.getLeagueUsers.mockResolvedValue([{ user_id: 'U1', display_name: 'Owner One' }]);
+
+        cache.getNflByeWeeksWithCache.mockResolvedValue({ KC: 5 });
+        cache.getNflScheduleWithCache.mockResolvedValue([]);
+        cache.getPlayersFromCacheOrFetch.mockResolvedValue({
+            p1: { full_name: 'Pat M', team: 'KC', position: 'QB', fantasy_positions: ['QB'], injury_status: null }
+        });
+        cache.hasTeamPlayedThisWeek.mockReturnValue(false);
+    });
+
+    it('completes when the week schedule fetch fails', async () => {
+        cache.getNflScheduleWithCache.mockRejectedValue(new Error('ESPN down'));
+
+        const result = await analyzeLeagueRosters('L1');
+
+        expect(result).toBeDefined();
+        expect(result.currentWeek).toBe(5);
+        expect(result.totalRosters).toBe(1);
+    });
+
+    it('completes when bye weeks fail to load', async () => {
+        cache.getNflByeWeeksWithCache.mockRejectedValue(new Error('bye weeks down'));
+
+        const result = await analyzeLeagueRosters('L1');
+
+        expect(result).toBeDefined();
+        expect(result.totalRosters).toBe(1);
+    });
+
+    it('completes when league users fail to load', async () => {
+        sleeper.getLeagueUsers.mockRejectedValue(new Error('users down'));
+
+        const result = await analyzeLeagueRosters('L1');
+
+        expect(result).toBeDefined();
+        expect(result.totalRosters).toBe(1);
+    });
+
+    it('fails fast when rosters cannot be loaded', async () => {
+        sleeper.getLeagueRosters.mockRejectedValue(new Error('rosters down'));
+
+        await expect(analyzeLeagueRosters('L1')).rejects.toThrow(/Unable to load rosters/);
+    });
+});

--- a/__tests__/services/sleeper.test.js
+++ b/__tests__/services/sleeper.test.js
@@ -1,0 +1,123 @@
+const sleeper = require('../../services/sleeper.js');
+const { resilientFetch } = sleeper;
+
+// Helper to build a minimal fetch Response-like object.
+const resp = (status, body) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `status ${status}`,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body))
+});
+
+describe('sleeper service resilience', () => {
+    let originalFetch;
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    describe('resilientFetch', () => {
+        it('returns the response on first success', async () => {
+            global.fetch = jest.fn().mockResolvedValue(resp(200, {}));
+
+            const result = await resilientFetch('http://example', { baseDelayMs: 0 });
+
+            expect(result.status).toBe(200);
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('retries on a transient 500 and then succeeds', async () => {
+            global.fetch = jest.fn()
+                .mockResolvedValueOnce(resp(500))
+                .mockResolvedValueOnce(resp(200, {}));
+
+            const result = await resilientFetch('http://example', { baseDelayMs: 0, attempts: 3 });
+
+            expect(result.status).toBe(200);
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('retries on a network error and then succeeds', async () => {
+            global.fetch = jest.fn()
+                .mockRejectedValueOnce(new Error('ECONNRESET'))
+                .mockResolvedValueOnce(resp(200, {}));
+
+            const result = await resilientFetch('http://example', { baseDelayMs: 0 });
+
+            expect(result.status).toBe(200);
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('retries on a timeout (AbortError) and then succeeds', async () => {
+            const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
+            global.fetch = jest.fn()
+                .mockRejectedValueOnce(abortError)
+                .mockResolvedValueOnce(resp(200, {}));
+
+            const result = await resilientFetch('http://example', { baseDelayMs: 0 });
+
+            expect(result.status).toBe(200);
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not retry on a 404 and returns the response', async () => {
+            global.fetch = jest.fn().mockResolvedValue(resp(404));
+
+            const result = await resilientFetch('http://example', { baseDelayMs: 0, attempts: 3 });
+
+            expect(result.status).toBe(404);
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('gives up after the max attempts and throws the last error', async () => {
+            global.fetch = jest.fn().mockRejectedValue(new Error('service down'));
+
+            await expect(resilientFetch('http://example', { baseDelayMs: 0, attempts: 3 }))
+                .rejects.toThrow('service down');
+            expect(global.fetch).toHaveBeenCalledTimes(3);
+        });
+
+        it('returns the last response when a retryable status persists', async () => {
+            global.fetch = jest.fn().mockResolvedValue(resp(503));
+
+            const result = await resilientFetch('http://example', { baseDelayMs: 0, attempts: 2 });
+
+            expect(result.status).toBe(503);
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('sleeperRequest (via getLeague)', () => {
+        it('parses and returns JSON on success', async () => {
+            global.fetch = jest.fn().mockResolvedValue(resp(200, { league_id: 'L1' }));
+
+            const result = await sleeper.getLeague('L1');
+
+            expect(result).toEqual({ league_id: 'L1' });
+        });
+
+        it('returns null when Sleeper responds 200 with a null body', async () => {
+            global.fetch = jest.fn().mockResolvedValue(resp(200, null));
+
+            const result = await sleeper.getLeague('missing');
+
+            expect(result).toBeNull();
+        });
+
+        it('retries then throws on persistent server errors', async () => {
+            global.fetch = jest.fn().mockResolvedValue(resp(500, 'boom'));
+
+            await expect(sleeper.getLeague('L1')).rejects.toThrow(/Sleeper API request failed/);
+            expect(global.fetch).toHaveBeenCalledTimes(3);
+        });
+    });
+});

--- a/services/rosterAnalyzer.js
+++ b/services/rosterAnalyzer.js
@@ -38,13 +38,35 @@ async function analyzeLeagueRosters(leagueId) {
 
         console.log(`[ROSTER_ANALYZER] Analyzing league ${leagueId} for season ${currentSeason}, week ${currentWeek}`);
 
-        // Get league data and bye weeks/schedule data in parallel
-        const [rosters, users, byeWeeks, weekSchedule] = await Promise.all([
+        // Fetch rosters and supporting data in parallel. Rosters are required;
+        // the rest degrade gracefully so a single transient upstream failure
+        // doesn't sink the entire analysis.
+        const [rostersResult, usersResult, byeWeeksResult, scheduleResult] = await Promise.allSettled([
             getLeagueRosters(leagueId),
             getLeagueUsers(leagueId),
             getNflByeWeeksWithCache(currentSeason),
             getNflScheduleWithCache(currentSeason, currentWeek)
         ]);
+
+        if (rostersResult.status !== 'fulfilled' || !rostersResult.value) {
+            throw new Error(`Unable to load rosters for league ${leagueId}: ${rostersResult.reason?.message || 'no roster data'}`);
+        }
+        const rosters = rostersResult.value;
+
+        const users = (usersResult.status === 'fulfilled' && Array.isArray(usersResult.value)) ? usersResult.value : [];
+        if (usersResult.status !== 'fulfilled') {
+            console.warn(`[ROSTER_ANALYZER] Failed to load league users; owner names unavailable this run: ${usersResult.reason?.message}`);
+        }
+
+        const byeWeeks = (byeWeeksResult.status === 'fulfilled' && byeWeeksResult.value) ? byeWeeksResult.value : {};
+        if (byeWeeksResult.status !== 'fulfilled') {
+            console.warn(`[ROSTER_ANALYZER] Failed to load bye weeks; bye detection disabled this run: ${byeWeeksResult.reason?.message}`);
+        }
+
+        const weekSchedule = (scheduleResult.status === 'fulfilled' && Array.isArray(scheduleResult.value)) ? scheduleResult.value : [];
+        if (scheduleResult.status !== 'fulfilled') {
+            console.warn(`[ROSTER_ANALYZER] Failed to load week schedule; already-played filtering disabled this run: ${scheduleResult.reason?.message}`);
+        }
 
         // Create user lookup map
         const userMap = {};

--- a/services/sleeper.js
+++ b/services/sleeper.js
@@ -6,6 +6,71 @@
 
 const API_BASE_URL = 'https://api.sleeper.app/v1';
 
+// Resilience defaults for outbound API calls.
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 200;
+// Transient statuses worth retrying. 4xx (other than 408/429) are caller errors
+// and are returned without retry.
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Exponential backoff with jitter, capped at 2s.
+ * @param {number} attempt 1-based attempt number that just failed.
+ * @param {number} baseDelayMs Base delay in milliseconds.
+ * @returns {number} Delay before the next attempt, in milliseconds.
+ */
+function backoffDelayMs(attempt, baseDelayMs) {
+    const capped = Math.min(baseDelayMs * 2 ** (attempt - 1), 2000);
+    return capped + Math.floor(Math.random() * 100);
+}
+
+/**
+ * fetch() with a per-attempt timeout and bounded retries with exponential backoff.
+ * Retries on network errors, timeouts, and transient HTTP statuses (408/429/5xx).
+ * Non-retryable responses (e.g. 404) are returned to the caller to handle.
+ * @param {string} url The URL to fetch.
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs] Per-attempt timeout.
+ * @param {number} [options.attempts] Max attempts (including the first).
+ * @param {number} [options.baseDelayMs] Base backoff delay.
+ * @param {string} [options.label] Label used in log messages.
+ * @returns {Promise<Response>} The fetch Response.
+ * @throws {Error} The last error if all attempts fail.
+ */
+async function resilientFetch(url, { timeoutMs = DEFAULT_TIMEOUT_MS, attempts = DEFAULT_ATTEMPTS, baseDelayMs = DEFAULT_BASE_DELAY_MS, label = 'API' } = {}) {
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const response = await fetch(url, { signal: controller.signal });
+            clearTimeout(timer);
+
+            if (RETRYABLE_STATUS.has(response.status) && attempt < attempts) {
+                console.warn(`[HTTP] ${label} returned ${response.status} (attempt ${attempt}/${attempts}), retrying...`);
+                lastError = new Error(`${label} request failed: ${response.status} ${response.statusText}`);
+                await delay(backoffDelayMs(attempt, baseDelayMs));
+                continue;
+            }
+            return response;
+        } catch (error) {
+            clearTimeout(timer);
+            lastError = error;
+            const reason = error.name === 'AbortError' ? `timeout after ${timeoutMs}ms` : error.message;
+            if (attempt < attempts) {
+                console.warn(`[HTTP] ${label} request error (${reason}) (attempt ${attempt}/${attempts}), retrying...`);
+                await delay(backoffDelayMs(attempt, baseDelayMs));
+                continue;
+            }
+            console.error(`[HTTP] ${label} request failed after ${attempts} attempts: ${reason}`);
+        }
+    }
+    throw lastError;
+}
+
 /**
  * A helper function to fetch data from the Sleeper API.
  * @param {string} endpoint The API endpoint to call, starting with a '/'.
@@ -15,7 +80,7 @@ const API_BASE_URL = 'https://api.sleeper.app/v1';
 async function sleeperRequest(endpoint) {
     const url = `${API_BASE_URL}${endpoint}`;
     try {
-        const response = await fetch(url);
+        const response = await resilientFetch(url, { label: 'Sleeper API' });
         if (!response.ok) {
             const errorBody = await response.text();
             throw new Error(`Sleeper API request failed: ${response.status} ${response.statusText} - ${errorBody}`);
@@ -152,9 +217,9 @@ function mapSleeperToEspnTeam(sleeperTeam) {
  */
 const getNflSchedule = async (season, week) => {
     const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?week=${week}&seasontype=2&year=${season}`;
-    
+
     try {
-        const response = await fetch(url);
+        const response = await resilientFetch(url, { label: 'ESPN API' });
         if (!response.ok) {
             throw new Error(`ESPN API request failed: ${response.status} ${response.statusText}`);
         }
@@ -214,4 +279,5 @@ module.exports = {
     getNflState,
     getNflSchedule,
     mapSleeperToEspnTeam,
+    resilientFetch,
 };


### PR DESCRIPTION
Second PR of the architecture hardening plan (docs/ARCHITECTURE_PLAN.md). The core fragility fix: the bot depends entirely on Sleeper (and ESPN for the schedule), and every call used a raw `fetch()` with no timeout or retry — a transient blip or slow response would hang to the Lambda timeout or fail the whole operation.

## Changes

### Resilient fetch (`services/sleeper.js`)
- New `resilientFetch()`: per-attempt timeout via `AbortController` (5s), bounded retries (3) with exponential backoff + jitter.
- Retries on network errors, timeouts, and transient HTTP statuses (408/429/5xx). **4xx are returned without retry** (caller errors).
- Both `sleeperRequest` and the ESPN `getNflSchedule` now route through it. Behavior for callers is unchanged on success and on real 4xx; only transient failures are now absorbed.

### Graceful degradation (`services/rosterAnalyzer.js`)
- `analyzeLeagueRosters` fans out with `Promise.allSettled` instead of `Promise.all`. **Rosters are required** (fail fast with a clear message); **league users, bye weeks, and the week schedule each degrade to a safe default** (empty owners / no bye detection / no already-played filtering) with a warning. One transient upstream failure no longer sinks the entire league analysis.

## Scope note
The bye-weeks, schedule, and player caches already degrade on error today (hardcoded fallback / empty results), so they aren't hard-failing. The deeper "serve expired cache value on refresh failure" item from the plan is **deferred to Phase 3**, which reworks the data-sourcing layer anyway — folding it there avoids touching the app-level TTL semantics twice.

## Tests
- New `sleeper.test.js`: success, retry-on-5xx, retry-on-network-error, retry-on-timeout, give-up-and-throw, no-retry-on-404, persistent-retryable returns last response, plus `sleeperRequest` JSON/null/error paths.
- New `rosterAnalyzer.degradation.test.js`: analysis completes when schedule/byes/users fail; fails fast when rosters are missing.
- Full suite **83 → 97 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)