### PR TITLE
Phase 3: ESPN-first bye weeks + weekly self-heal (kill the manual annual update)

### DIFF
--- a/__tests__/services/espn.test.js
+++ b/__tests__/services/espn.test.js
@@ -1,0 +1,69 @@
+// Mock the resilient fetch so these tests don't hit the network.
+jest.mock('../../services/sleeper.js', () => ({
+    resilientFetch: jest.fn()
+}));
+
+const { resilientFetch } = require('../../services/sleeper.js');
+const { fetchNflByeWeeks } = require('../../services/espn.js');
+
+// ESPN core API numeric team ids for every NFL team (matches services/espn.js).
+const TEAM_IDS = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 33, 34
+];
+
+// Build a fake ESPN week response with the given team ids on bye.
+const weekResponse = (teamIds) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+        teamsOnBye: teamIds.map((id) => ({ $ref: `http://x/teams/${id}?lang=en` }))
+    })
+});
+
+describe('espn.fetchNflByeWeeks', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('aggregates all 32 teams across weeks into a season map', async () => {
+        // Put 2 teams on bye in week 1, the rest in week 2; everything else empty.
+        resilientFetch.mockImplementation((url) => {
+            const week = parseInt(url.match(/weeks\/(\d+)/)[1], 10);
+            if (week === 1) return Promise.resolve(weekResponse(TEAM_IDS.slice(0, 2)));
+            if (week === 2) return Promise.resolve(weekResponse(TEAM_IDS.slice(2)));
+            return Promise.resolve(weekResponse([]));
+        });
+
+        const result = await fetchNflByeWeeks(2026);
+
+        expect(Object.keys(result)).toHaveLength(32);
+        // ESPN id 28 (WSH) must be mapped to Sleeper's WAS.
+        expect(result.WAS).toBeDefined();
+        expect(result.WSH).toBeUndefined();
+        // Team id 1 (ATL) was in week 1.
+        expect(result.ATL).toBe(1);
+    });
+
+    it('throws when ESPN data is incomplete (not all 32 teams)', async () => {
+        resilientFetch.mockImplementation((url) => {
+            const week = parseInt(url.match(/weeks\/(\d+)/)[1], 10);
+            // Only 30 teams ever appear on bye -> incomplete.
+            if (week === 1) return Promise.resolve(weekResponse(TEAM_IDS.slice(0, 30)));
+            return Promise.resolve(weekResponse([]));
+        });
+
+        await expect(fetchNflByeWeeks(2026)).rejects.toThrow(/incomplete.*30\/32/);
+    });
+
+    it('tolerates individual week failures but still throws if incomplete', async () => {
+        resilientFetch.mockRejectedValue(new Error('ESPN down'));
+
+        await expect(fetchNflByeWeeks(2026)).rejects.toThrow(/incomplete/);
+    });
+});

--- a/__tests__/services/nflDataCache.test.js
+++ b/__tests__/services/nflDataCache.test.js
@@ -15,22 +15,30 @@ const {
 // Mock the dependencies
 jest.mock('../../services/datastore.js');
 jest.mock('../../services/sleeper.js');
+jest.mock('../../services/espn.js');
 
 const mockDatastore = require('../../services/datastore.js');
 const mockSleeper = require('../../services/sleeper.js');
+const mockEspn = require('../../services/espn.js');
 
 describe('NFL Data Cache Service', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        
+
+        // Default: ESPN unavailable, so bye-week tests fall back to hardcoded data
+        // unless a test overrides this.
+        mockEspn.fetchNflByeWeeks.mockRejectedValue(new Error('ESPN unavailable'));
+
         // Reset console.log and console.error to avoid cluttering test output
         jest.spyOn(console, 'log').mockImplementation(() => {});
         jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
     });
 
     afterEach(() => {
         console.log.mockRestore();
         console.error.mockRestore();
+        console.warn.mockRestore();
     });
 
     describe('getNflByeWeeksWithCache', () => {
@@ -45,9 +53,23 @@ describe('NFL Data Cache Service', () => {
             expect(mockDatastore.saveNflByeWeeks).not.toHaveBeenCalled();
         });
 
-        it('should return hardcoded data and cache it if not cached', async () => {
+        it('should fetch from ESPN and cache it when not cached', async () => {
+            const espnByeWeeks = { 'KC': 5, 'CAR': 5 };
             mockDatastore.getNflByeWeeks.mockResolvedValue(null);
             mockDatastore.saveNflByeWeeks.mockResolvedValue();
+            mockEspn.fetchNflByeWeeks.mockResolvedValue(espnByeWeeks);
+
+            const result = await getNflByeWeeksWithCache(2025);
+
+            expect(result).toEqual(espnByeWeeks);
+            expect(mockEspn.fetchNflByeWeeks).toHaveBeenCalledWith(2025);
+            expect(mockDatastore.saveNflByeWeeks).toHaveBeenCalledWith(2025, espnByeWeeks);
+        });
+
+        it('should fall back to hardcoded data and cache it when ESPN is unavailable', async () => {
+            mockDatastore.getNflByeWeeks.mockResolvedValue(null);
+            mockDatastore.saveNflByeWeeks.mockResolvedValue();
+            // mockEspn.fetchNflByeWeeks rejects by default (see beforeEach)
 
             const result = await getNflByeWeeksWithCache(2025);
 

--- a/services/datastore.js
+++ b/services/datastore.js
@@ -499,8 +499,11 @@ async function saveNflByeWeeks(season, byeWeeks) {
                 season: season,
                 byeWeeks: byeWeeks,
                 cachedAt: new Date().toISOString(),
-                // Cache expires after 1 year (season ends)
-                expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()
+                // Short TTL so the scheduled roster checks re-fetch from ESPN ~weekly
+                // and pick up any mid-season bye-week corrections.
+                expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+                // DynamoDB TTL (epoch seconds) so expired entries are auto-purged.
+                ttl: Math.floor((Date.now() + 7 * 24 * 60 * 60 * 1000) / 1000)
             }
         });
         

--- a/services/espn.js
+++ b/services/espn.js
@@ -1,0 +1,80 @@
+/**
+ * ESPN data access for NFL bye weeks.
+ *
+ * Bye weeks are derived from ESPN's core API, which lists `teamsOnBye` per week.
+ * This is the live source of truth used by the cache layer; the hardcoded tables
+ * in nflDataCache.js are only a fallback when ESPN is unavailable or invalid.
+ */
+
+const { resilientFetch } = require('./sleeper.js');
+const { mapEspnToSleeperTeam } = require('../shared/teamMappings.js');
+
+// ESPN core API numeric team id -> abbreviation (verified against the ESPN API).
+const ESPN_TEAM_ID_TO_ABBR = {
+    1: 'ATL', 2: 'BUF', 3: 'CHI', 4: 'CIN', 5: 'CLE', 6: 'DAL', 7: 'DEN', 8: 'DET',
+    9: 'GB', 10: 'TEN', 11: 'IND', 12: 'KC', 13: 'LV', 14: 'LAR', 15: 'MIA', 16: 'MIN',
+    17: 'NE', 18: 'NO', 19: 'NYG', 20: 'NYJ', 21: 'PHI', 22: 'ARI', 23: 'PIT', 24: 'LAC',
+    25: 'SF', 26: 'SEA', 27: 'TB', 28: 'WSH', 29: 'CAR', 30: 'JAX', 33: 'BAL', 34: 'HOU'
+};
+
+const NFL_TEAM_COUNT = 32;
+const REGULAR_SEASON_WEEKS = 18;
+
+/**
+ * Fetch the teams on bye for a single week from the ESPN core API.
+ * @param {string|number} season The season year.
+ * @param {number} week The week number (1-18).
+ * @returns {Promise<string[]>} Team abbreviations (Sleeper format) on bye that week.
+ */
+async function fetchWeekByes(season, week) {
+    const url = `https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/${season}/types/2/weeks/${week}`;
+    const response = await resilientFetch(url, { label: `ESPN byes wk${week}` });
+    if (!response.ok) {
+        throw new Error(`ESPN bye-week request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const teams = [];
+    for (const ref of data.teamsOnBye || []) {
+        const teamId = ref.$ref?.match(/teams\/(\d+)/)?.[1];
+        const abbr = teamId && ESPN_TEAM_ID_TO_ABBR[teamId];
+        if (abbr) {
+            teams.push(mapEspnToSleeperTeam(abbr));
+        }
+    }
+    return teams;
+}
+
+/**
+ * Fetch and validate the full NFL bye-week map for a season from ESPN.
+ * Weeks are fetched in parallel. Throws if the result is incomplete so callers
+ * can fall back to hardcoded data rather than serve a partial/invalid map.
+ * @param {string|number} season The season year (e.g. 2026).
+ * @returns {Promise<object>} Map of team abbreviation (Sleeper format) -> bye week.
+ * @throws {Error} if ESPN data is incomplete (not all 32 teams accounted for).
+ */
+async function fetchNflByeWeeks(season) {
+    const weeks = Array.from({ length: REGULAR_SEASON_WEEKS }, (_, i) => i + 1);
+    const results = await Promise.allSettled(weeks.map((week) => fetchWeekByes(season, week)));
+
+    const byeWeeks = {};
+    results.forEach((result, idx) => {
+        if (result.status === 'fulfilled') {
+            for (const team of result.value) {
+                byeWeeks[team] = idx + 1;
+            }
+        }
+    });
+
+    const teamsFound = Object.keys(byeWeeks).length;
+    if (teamsFound !== NFL_TEAM_COUNT) {
+        throw new Error(`ESPN bye weeks incomplete for ${season}: ${teamsFound}/${NFL_TEAM_COUNT} teams`);
+    }
+
+    return byeWeeks;
+}
+
+module.exports = {
+    fetchNflByeWeeks,
+    ESPN_TEAM_ID_TO_ABBR
+};

--- a/services/nflDataCache.js
+++ b/services/nflDataCache.js
@@ -10,6 +10,8 @@
 
 const { saveNflByeWeeks, getNflByeWeeks, saveNflPlayers, getNflPlayers, saveNflSchedule, getNflSchedule } = require('./datastore.js');
 const { getAllPlayers: sleeperGetAllPlayers, getNflState } = require('./sleeper.js');
+const { fetchNflByeWeeks } = require('./espn.js');
+const { mapSleeperToEspnTeam } = require('../shared/teamMappings.js');
 
 /**
  * NFL teams and their bye weeks for 2025 season
@@ -81,29 +83,39 @@ const NFL_BYE_WEEKS_BY_SEASON = {
 async function getNflByeWeeksWithCache(season) {
     try {
         console.log(`[CACHE] Getting NFL bye weeks for ${season} season`);
-        
-        // Try to get from cache first
+
+        // 1. Fresh cache wins (cheap, and avoids hammering ESPN).
         const cachedByeWeeks = await getNflByeWeeks(season);
         if (cachedByeWeeks) {
             console.log(`[CACHE] Using cached NFL bye weeks for ${season} season`);
             return cachedByeWeeks;
         }
 
-        // Fall back to hardcoded data
-        const byeWeeks = NFL_BYE_WEEKS_BY_SEASON[season];
+        // 2. Live ESPN data, validated. This is the source of truth: it lets new
+        //    seasons work without a code change and picks up mid-season
+        //    corrections. fetchNflByeWeeks throws if the data is incomplete.
+        let byeWeeks;
+        try {
+            byeWeeks = await fetchNflByeWeeks(season);
+            console.log(`[CACHE] Fetched ${Object.keys(byeWeeks).length} bye weeks from ESPN for ${season}`);
+        } catch (espnError) {
+            // 3. Fall back to the hardcoded table when ESPN is unavailable/invalid.
+            console.warn(`[CACHE] ESPN bye-week fetch failed for ${season}, falling back to hardcoded data: ${espnError.message}`);
+            byeWeeks = NFL_BYE_WEEKS_BY_SEASON[season];
+        }
+
         if (!byeWeeks) {
             throw new Error(`No bye week data available for ${season} season`);
         }
 
-        // Cache the bye weeks data
+        // Cache the resolved data (short TTL so the scheduler re-fetches weekly).
         console.log(`[CACHE] Caching NFL bye weeks for ${season} season`);
         await saveNflByeWeeks(season, byeWeeks);
-        console.log(`[CACHE] Successfully cached NFL bye weeks for ${season} season`);
-        
+
         return byeWeeks;
     } catch (error) {
         console.error(`Error getting NFL bye weeks for ${season}:`, error);
-        // Return hardcoded data as last resort
+        // Return hardcoded data as last resort.
         return NFL_BYE_WEEKS_BY_SEASON[season] || {};
     }
 }
@@ -238,14 +250,25 @@ async function refreshNflPlayersCache(sport = 'nfl') {
 async function refreshNflByeWeeksCache(season) {
     try {
         console.log(`[CACHE] Force refreshing NFL bye weeks for ${season} season`);
-        const byeWeeks = NFL_BYE_WEEKS_BY_SEASON[season];
+
+        // Prefer live ESPN data so a forced refresh picks up corrections; fall
+        // back to the hardcoded table when ESPN is unavailable/invalid.
+        let byeWeeks;
+        try {
+            byeWeeks = await fetchNflByeWeeks(season);
+            console.log(`[CACHE] Fetched ${Object.keys(byeWeeks).length} bye weeks from ESPN for ${season}`);
+        } catch (espnError) {
+            console.warn(`[CACHE] ESPN bye-week fetch failed for ${season}, falling back to hardcoded data: ${espnError.message}`);
+            byeWeeks = NFL_BYE_WEEKS_BY_SEASON[season];
+        }
+
         if (!byeWeeks) {
             throw new Error(`No bye week data available for ${season} season`);
         }
 
         await saveNflByeWeeks(season, byeWeeks);
         console.log(`[CACHE] Refreshed NFL bye weeks cache for ${season} season`);
-        
+
         return byeWeeks;
     } catch (error) {
         console.error(`Error refreshing NFL bye weeks cache for ${season}:`, error);
@@ -367,20 +390,6 @@ async function getNflScheduleWithCache(season, week) {
         // Return empty array rather than throwing - allows roster analysis to continue
         return [];
     }
-}
-
-/**
- * Maps Sleeper team abbreviations to ESPN team abbreviations.
- * Sleeper uses 'WAS' for Washington, but ESPN schedule API uses 'WSH'.
- * @param {string} sleeperTeam The team abbreviation from Sleeper.
- * @returns {string} The corresponding ESPN team abbreviation.
- */
-function mapSleeperToEspnTeam(sleeperTeam) {
-    const teamMap = {
-        'WAS': 'WSH',  // Washington: Sleeper uses WAS, ESPN uses WSH
-        // Add other mappings if needed
-    };
-    return teamMap[sleeperTeam] || sleeperTeam;
 }
 
 /**

--- a/services/sleeper.js
+++ b/services/sleeper.js
@@ -4,6 +4,8 @@
  * If you are using an older version of Node.js, you may need to install a polyfill like 'node-fetch'.
  */
 
+const { mapSleeperToEspnTeam } = require('../shared/teamMappings.js');
+
 const API_BASE_URL = 'https://api.sleeper.app/v1';
 
 // Resilience defaults for outbound API calls.
@@ -194,20 +196,6 @@ const getAllPlayers = (sport = 'nfl') => {
 const getNflState = () => {
     return sleeperRequest('/state/nfl');
 };
-
-/**
- * Maps Sleeper team abbreviations to ESPN team abbreviations.
- * Sleeper uses 'WAS' for Washington, but ESPN schedule API uses 'WSH'.
- * @param {string} sleeperTeam The team abbreviation from Sleeper.
- * @returns {string} The corresponding ESPN team abbreviation.
- */
-function mapSleeperToEspnTeam(sleeperTeam) {
-    const teamMap = {
-        'WAS': 'WSH',  // Washington: Sleeper uses WAS, ESPN uses WSH
-        // Add other mappings if needed
-    };
-    return teamMap[sleeperTeam] || sleeperTeam;
-}
 
 /**
  * Get NFL schedule for a specific week and season using ESPN API.

--- a/shared/teamMappings.js
+++ b/shared/teamMappings.js
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for NFL team abbreviation differences between providers.
+ * Sleeper uses 'WAS' for Washington; ESPN uses 'WSH'. Add future mismatches here.
+ */
+const SLEEPER_TO_ESPN = {
+    WAS: 'WSH'
+};
+
+const ESPN_TO_SLEEPER = Object.fromEntries(
+    Object.entries(SLEEPER_TO_ESPN).map(([sleeper, espn]) => [espn, sleeper])
+);
+
+/**
+ * Map a Sleeper team abbreviation to ESPN's abbreviation.
+ * @param {string} sleeperTeam Team abbreviation in Sleeper format.
+ * @returns {string} The ESPN abbreviation (unchanged if no mapping needed).
+ */
+function mapSleeperToEspnTeam(sleeperTeam) {
+    return SLEEPER_TO_ESPN[sleeperTeam] || sleeperTeam;
+}
+
+/**
+ * Map an ESPN team abbreviation to Sleeper's abbreviation.
+ * @param {string} espnTeam Team abbreviation in ESPN format.
+ * @returns {string} The Sleeper abbreviation (unchanged if no mapping needed).
+ */
+function mapEspnToSleeperTeam(espnTeam) {
+    return ESPN_TO_SLEEPER[espnTeam] || espnTeam;
+}
+
+module.exports = {
+    SLEEPER_TO_ESPN,
+    ESPN_TO_SLEEPER,
+    mapSleeperToEspnTeam,
+    mapEspnToSleeperTeam
+};

--- a/update-bye-weeks.js
+++ b/update-bye-weeks.js
@@ -1,169 +1,68 @@
 #!/usr/bin/env node
 /**
- * Utility script to fetch and update NFL bye weeks for a given season using ESPN API
+ * Manual tool to fetch NFL bye weeks for a season and print them in the format
+ * used by the hardcoded fallback tables in services/nflDataCache.js.
+ *
+ * The bot fetches bye weeks from ESPN automatically at runtime (see
+ * services/espn.js + getNflByeWeeksWithCache); this script is only needed to
+ * regenerate the hardcoded fallback when you want a reviewed, committed copy.
+ *
  * Usage: node update-bye-weeks.js [season]
- * Example: node update-bye-weeks.js 2025
+ * Example: node update-bye-weeks.js 2026
  */
 
-const https = require('https');
-const fs = require('fs');
-const path = require('path');
+const { fetchNflByeWeeks } = require('./services/espn.js');
 
-// Complete ESPN team ID mapping (verified with ESPN API)
-const ESPN_TEAM_ID_TO_ABBR = {
-    1: 'ATL',   2: 'BUF',   3: 'CHI',   4: 'CIN',   5: 'CLE',   6: 'DAL',   7: 'DEN',   8: 'DET',
-    9: 'GB',    10: 'TEN',  11: 'IND',  12: 'KC',   13: 'LV',   14: 'LAR',  15: 'MIA',  16: 'MIN',
-    17: 'NE',   18: 'NO',   19: 'NYG',  20: 'NYJ',  21: 'PHI',  22: 'ARI',  23: 'PIT',  24: 'LAC',
-    25: 'SF',   26: 'SEA',  27: 'TB',   28: 'WSH',  29: 'CAR',  30: 'JAX',  33: 'BAL',  34: 'HOU'
-};
-
-// Map ESPN abbreviations to Sleeper abbreviations (for consistency)
-const ESPN_TO_SLEEPER_MAPPING = {
-    'WSH': 'WAS'  // ESPN uses WSH, but Sleeper uses WAS
-};
-
-function makeRequest(url) {
-    return new Promise((resolve, reject) => {
-        https.get(url, (res) => {
-            let data = '';
-            res.on('data', (chunk) => data += chunk);
-            res.on('end', () => {
-                try {
-                    resolve(JSON.parse(data));
-                } catch (error) {
-                    reject(error);
-                }
-            });
-        }).on('error', reject);
-    });
-}
-
-async function fetchByeWeeksForSeason(season) {
-    console.log(`🏈 Fetching ${season} NFL Bye Weeks from ESPN API...\n`);
-    
-    const byeWeeksData = {};
-    const weekResults = [];
-    
-    for (let week = 1; week <= 18; week++) {
-        try {
-            const url = `https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/${season}/types/2/weeks/${week}`;
-            const weekData = await makeRequest(url);
-            
-            const teamsOnBye = [];
-            
-            if (weekData.teamsOnBye && weekData.teamsOnBye.length > 0) {
-                console.log(`Week ${week}: ${weekData.teamsOnBye.length} teams on bye`);
-                
-                for (const teamRef of weekData.teamsOnBye) {
-                    const teamId = teamRef.$ref.match(/teams\/(\d+)/)?.[1];
-                    if (teamId && ESPN_TEAM_ID_TO_ABBR[teamId]) {
-                        let teamAbbr = ESPN_TEAM_ID_TO_ABBR[teamId];
-                        
-                        // Convert ESPN abbreviation to Sleeper format if needed
-                        if (ESPN_TO_SLEEPER_MAPPING[teamAbbr]) {
-                            console.log(`  - Team ID ${teamId}: ${teamAbbr} → ${ESPN_TO_SLEEPER_MAPPING[teamAbbr]} (Sleeper format)`);
-                            teamAbbr = ESPN_TO_SLEEPER_MAPPING[teamAbbr];
-                        } else {
-                            console.log(`  - Team ID ${teamId}: ${teamAbbr}`);
-                        }
-                        
-                        teamsOnBye.push(teamAbbr);
-                    } else {
-                        console.log(`  - Unknown team ID: ${teamId}`);
-                    }
-                }
-            }
-            
-            weekResults.push({ week, teams: teamsOnBye });
-            
-            // Small delay to be respectful to the API
-            await new Promise(resolve => setTimeout(resolve, 100));
-        } catch (error) {
-            console.error(`Error fetching week ${week}:`, error.message);
-            weekResults.push({ week, teams: [] });
-        }
-    }
-    
-    // Convert to bye weeks format
-    weekResults.forEach(({ week, teams }) => {
-        teams.forEach(team => {
-            byeWeeksData[team] = week;
-        });
-    });
-    
-    return { byeWeeksData, weekResults };
-}
-
-function displayResults(season, byeWeeksData, weekResults) {
+function displayResults(season, byeWeeksData) {
     console.log(`\n📊 ${season} NFL Bye Weeks Summary:`);
     console.log('='.repeat(70));
-    
-    // Group by week for display
+
+    // Group teams by bye week for display.
     const byWeek = {};
     Object.entries(byeWeeksData).forEach(([team, week]) => {
         if (!byWeek[week]) byWeek[week] = [];
         byWeek[week].push(team);
     });
-    
-    Object.keys(byWeek).sort((a, b) => parseInt(a) - parseInt(b)).forEach(week => {
+
+    const sortedWeeks = Object.keys(byWeek).sort((a, b) => parseInt(a) - parseInt(b));
+    sortedWeeks.forEach((week) => {
         const teams = byWeek[week].sort();
         console.log(`Week ${week.toString().padStart(2)} (${teams.length} teams): ${teams.join(', ')}`);
     });
-    
+
     console.log(`\nTotal teams: ${Object.keys(byeWeeksData).length}`);
-    
-    console.log('\n📝 JavaScript Object Format:');
+
+    console.log('\n📝 JavaScript Object Format (for nflDataCache.js fallback):');
     console.log('='.repeat(70));
     console.log(`const NFL_BYE_WEEKS_${season} = {`);
-    
-    Object.keys(byWeek).sort((a, b) => parseInt(a) - parseInt(b)).forEach(week => {
+    sortedWeeks.forEach((week) => {
         const teams = byWeek[week].sort();
         console.log(`    // Week ${week} byes`);
-        const teamEntries = teams.map(team => `'${team}': ${week}`).join(', ');
-        console.log(`    ${teamEntries},`);
+        console.log(`    ${teams.map((team) => `'${team}': ${week}`).join(', ')},`);
     });
-    
     console.log('};');
-    
-    // Validation
-    console.log('\n🔍 Validation:');
-    console.log('='.repeat(70));
-    const allNflTeams = ['ARI', 'ATL', 'BAL', 'BUF', 'CAR', 'CHI', 'CIN', 'CLE', 'DAL', 'DEN', 
-                        'DET', 'GB', 'HOU', 'IND', 'JAX', 'KC', 'LV', 'LAC', 'LAR', 'MIA', 
-                        'MIN', 'NE', 'NO', 'NYG', 'NYJ', 'PHI', 'PIT', 'SF', 'SEA', 'TB', 
-                        'TEN', 'WAS'];
-    
-    const teamsWithByes = Object.keys(byeWeeksData).sort();
-    const missingTeams = allNflTeams.filter(team => !teamsWithByes.includes(team));
-    
-    console.log(`Teams with bye weeks (${teamsWithByes.length}): ${teamsWithByes.join(', ')}`);
-    if (missingTeams.length > 0) {
-        console.log(`❌ Missing teams (${missingTeams.length}): ${missingTeams.join(', ')}`);
-    } else {
-        console.log('✅ All 32 NFL teams accounted for!');
-    }
 }
 
 async function main() {
-    const season = process.argv[2] || '2025';
-    
+    const season = process.argv[2] || String(new Date().getFullYear());
+
     if (!/^\d{4}$/.test(season)) {
-        console.error('❌ Invalid season format. Use 4-digit year (e.g., 2025)');
+        console.error('❌ Invalid season format. Use a 4-digit year (e.g., 2026)');
         process.exit(1);
     }
-    
+
     try {
-        const { byeWeeksData, weekResults } = await fetchByeWeeksForSeason(season);
-        displayResults(season, byeWeeksData, weekResults);
-        
-        console.log(`\n✅ ${season} bye weeks fetching completed!`);
-        console.log('\n📝 To update the code:');
-        console.log('1. Copy the JavaScript object above');
-        console.log('2. Update NFL_BYE_WEEKS_' + season + ' in services/nflDataCache.js');
-        console.log('3. Clear the cache to use new data');
-        
+        console.log(`🏈 Fetching ${season} NFL bye weeks from ESPN...`);
+        const byeWeeksData = await fetchNflByeWeeks(season);
+        displayResults(season, byeWeeksData);
+
+        console.log(`\n✅ ${season} bye weeks fetched and validated (all 32 teams).`);
+        console.log('\n📝 To refresh the hardcoded fallback:');
+        console.log(`1. Copy the object above into NFL_BYE_WEEKS_${season} in services/nflDataCache.js`);
+        console.log(`2. Register it in NFL_BYE_WEEKS_BY_SEASON`);
+        console.log('(The bot already uses live ESPN data at runtime; this is only the fallback.)');
     } catch (error) {
-        console.error('❌ Error fetching bye weeks:', error);
+        console.error(`❌ Error fetching bye weeks for ${season}:`, error.message);
         process.exit(1);
     }
 }
@@ -172,4 +71,4 @@ if (require.main === module) {
     main();
 }
 
-module.exports = { fetchByeWeeksForSeason };
+module.exports = { fetchNflByeWeeks };


### PR DESCRIPTION
Third PR of the architecture hardening plan (docs/ARCHITECTURE_PLAN.md). Removes the manual annual bye-week update — the recurring tax that kicked off this whole effort.

**Approach (confirmed with the owner):** ESPN-first with validation; the hardcoded tables become a validated *fallback*. Short TTL rides the existing scheduler to propagate corrections.

## Changes

### Live data sourcing (`services/espn.js`, `services/nflDataCache.js`)
- New `services/espn.js`: `fetchNflByeWeeks(season)` pulls each week's `teamsOnBye` from ESPN's core API in parallel (using the Phase 2 `resilientFetch`), maps ESPN ids → Sleeper abbreviations, and **validates all 32 teams are present** (throws otherwise, so callers fall back rather than serve a partial map).
- `getNflByeWeeksWithCache` and `refreshNflByeWeeksCache` are now **ESPN-first**: fresh cache → validated ESPN → hardcoded fallback. A brand-new season works with **no code change**; mid-season ESPN corrections (like 2025-10-03) propagate automatically.

### Self-heal cadence (`services/datastore.js`)
- Bye-weeks cache TTL cut **365 days → 7 days** (plus a DynamoDB `ttl` attribute for auto-purge, now that Phase 1 enabled TTL), so the existing 3×/week roster-scheduler re-fetches from ESPN about weekly. **No new infrastructure.**

### DRY (`shared/teamMappings.js`)
- Single source of truth for the Sleeper↔ESPN abbreviation differences (WAS/WSH). Removes the duplicated maps in `sleeper.js` and `nflDataCache.js`, and a third copy + bespoke ESPN fetch in `update-bye-weeks.js` (now delegates to `espn.js`).

## Verification
- `update-bye-weeks.js 2026` run against live ESPN through the new service produces output identical to the committed 2026 table (WSH→WAS mapped) — exercises the runtime ESPN-first path end-to-end.
- New `espn.test.js` (aggregation across weeks, 32-team validation failure, per-week failure tolerance) + ESPN-first cache tests. Full suite **97 → 101 passing**.

## Notes
- The hardcoded `NFL_BYE_WEEKS_20xx` tables remain as the offline fallback and still gate nothing — ESPN can now introduce a new season on its own. They can be refreshed anytime with `update-bye-weeks.js`.
- This also absorbs the serve-stale item deferred from Phase 2: when ESPN is unavailable, the resolved value falls back to hardcoded rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)