### PR TITLE
Phase 4: test-coverage backfill + CI coverage ratchet

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   # Test and validate the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,16 @@ on:
     branches: [ main, develop ]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        node-version: ['18', '20']
+        node-version: ['20', '22']
     
     steps:
       - name: Checkout code

--- a/__tests__/services/datastore.test.js
+++ b/__tests__/services/datastore.test.js
@@ -33,7 +33,16 @@ const {
     getDraft,
     saveDraft,
     getDraftsByChannel,
-    getLeaguesByChannel
+    getLeaguesByChannel,
+    updatePlayerSlackName,
+    getAllPlayers,
+    saveLeague,
+    getLeague,
+    getAllChannelsWithLeagues,
+    saveNflByeWeeks,
+    getNflByeWeeks,
+    getNflSchedule,
+    getNflPlayers
 } = require('../../services/datastore.js');
 
 const { QueryCommand, ScanCommand } = require('@aws-sdk/lib-dynamodb');
@@ -290,6 +299,114 @@ describe('DynamoDB Datastore Service', () => {
 
             expect(ScanCommand).toHaveBeenCalled();
             expect(result).toEqual(items);
+        });
+    });
+
+    describe('updatePlayerSlackName', () => {
+        it('updates an existing player', async () => {
+            mockSend
+                .mockResolvedValueOnce({ Item: { sleeperId: '123', slackMemberId: 'U1', slackName: 'Old' } }) // getPlayer
+                .mockResolvedValueOnce({}); // put
+
+            await updatePlayerSlackName('123', 'New');
+
+            expect(mockSend).toHaveBeenCalledTimes(2);
+        });
+
+        it('throws when the player does not exist', async () => {
+            mockSend.mockResolvedValueOnce({}); // getPlayer -> no Item
+
+            await expect(updatePlayerSlackName('999', 'New')).rejects.toThrow(/not found/);
+        });
+    });
+
+    describe('getAllPlayers', () => {
+        it('queries the PLAYER partition and maps the results', async () => {
+            mockSend.mockResolvedValue({
+                Items: [{ sleeperId: '1', slackMemberId: 'U1', slackName: 'Alice' }]
+            });
+
+            const result = await getAllPlayers();
+
+            expect(result).toEqual([{ sleeperId: '1', slackMemberId: 'U1', slackName: 'Alice' }]);
+        });
+    });
+
+    describe('saveLeague / getLeague', () => {
+        it('saves a league item', async () => {
+            mockSend.mockResolvedValue({});
+
+            await saveLeague('L1', 'C1', { name: 'Test', season: 2025, sport: 'nfl', total_rosters: 12, status: 'in_season' });
+
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns the league item when found, null otherwise', async () => {
+            mockSend.mockResolvedValueOnce({ Item: { leagueId: 'L1', leagueName: 'Test' } });
+            await expect(getLeague('L1')).resolves.toEqual({ leagueId: 'L1', leagueName: 'Test' });
+
+            mockSend.mockResolvedValueOnce({});
+            await expect(getLeague('missing')).resolves.toBeNull();
+        });
+    });
+
+    describe('getAllChannelsWithLeagues', () => {
+        it('groups leagues by channel id', async () => {
+            mockSend.mockResolvedValue({
+                Items: [
+                    { leagueId: 'L1', slackChannelId: 'C1' },
+                    { leagueId: 'L2', slackChannelId: 'C1' },
+                    { leagueId: 'L3', slackChannelId: 'C2' }
+                ]
+            });
+
+            const result = await getAllChannelsWithLeagues();
+
+            expect(result).toHaveLength(2);
+            const c1 = result.find((c) => c.channelId === 'C1');
+            expect(c1.leagues).toHaveLength(2);
+        });
+    });
+
+    describe('NFL cache expiry', () => {
+        const future = new Date(Date.now() + 60_000).toISOString();
+        const past = new Date(Date.now() - 60_000).toISOString();
+
+        it('saveNflByeWeeks writes an item with a ttl', async () => {
+            mockSend.mockResolvedValue({});
+            await saveNflByeWeeks(2026, { KC: 5 });
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+
+        it('getNflByeWeeks returns data when fresh', async () => {
+            mockSend.mockResolvedValue({ Item: { byeWeeks: { KC: 5 }, expiresAt: future } });
+            await expect(getNflByeWeeks(2026)).resolves.toEqual({ KC: 5 });
+        });
+
+        it('getNflByeWeeks returns null when expired', async () => {
+            mockSend.mockResolvedValue({ Item: { byeWeeks: { KC: 5 }, expiresAt: past } });
+            await expect(getNflByeWeeks(2026)).resolves.toBeNull();
+        });
+
+        it('getNflByeWeeks returns null when missing', async () => {
+            mockSend.mockResolvedValue({});
+            await expect(getNflByeWeeks(2026)).resolves.toBeNull();
+        });
+
+        it('getNflSchedule returns games when fresh and null when expired', async () => {
+            mockSend.mockResolvedValueOnce({ Item: { season: 2026, week: 5, games: [{ home_team: 'KC' }], expiresAt: future } });
+            await expect(getNflSchedule(2026, 5)).resolves.toMatchObject({ games: [{ home_team: 'KC' }] });
+
+            mockSend.mockResolvedValueOnce({ Item: { expiresAt: past } });
+            await expect(getNflSchedule(2026, 5)).resolves.toBeNull();
+        });
+
+        it('getNflPlayers returns players when fresh and null when expired', async () => {
+            mockSend.mockResolvedValueOnce({ Item: { players: { p1: {} }, playerCount: 1, expiresAt: future } });
+            await expect(getNflPlayers('nfl')).resolves.toEqual({ p1: {} });
+
+            mockSend.mockResolvedValueOnce({ Item: { players: {}, expiresAt: past } });
+            await expect(getNflPlayers('nfl')).resolves.toBeNull();
         });
     });
 });

--- a/__tests__/services/slackUtils.test.js
+++ b/__tests__/services/slackUtils.test.js
@@ -1,0 +1,120 @@
+const {
+    resolveSlackUsername,
+    resolveSlackUsernames,
+    updateAllPlayerSlackNames
+} = require('../../services/slackUtils.js');
+
+// Build a fake Bolt app whose users.info returns a canned response per member id.
+const makeApp = (usersById) => ({
+    client: {
+        users: {
+            info: jest.fn(async ({ user }) => {
+                if (usersById[user] === undefined) {
+                    throw new Error('user_not_found');
+                }
+                return usersById[user];
+            })
+        }
+    }
+});
+
+describe('slackUtils', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('resolveSlackUsername', () => {
+        it('prefers display_name', async () => {
+            const app = makeApp({ U1: { ok: true, user: { profile: { display_name: 'Disp', real_name: 'Real' }, name: 'handle' } } });
+            await expect(resolveSlackUsername(app, 'U1')).resolves.toBe('Disp');
+        });
+
+        it('falls back to real_name then handle then memberId', async () => {
+            const realOnly = makeApp({ U1: { ok: true, user: { profile: { real_name: 'Real' }, name: 'handle' } } });
+            await expect(resolveSlackUsername(realOnly, 'U1')).resolves.toBe('Real');
+
+            const handleOnly = makeApp({ U2: { ok: true, user: { profile: {}, name: 'handle' } } });
+            await expect(resolveSlackUsername(handleOnly, 'U2')).resolves.toBe('handle');
+
+            const nothing = makeApp({ U3: { ok: true, user: { profile: {} } } });
+            await expect(resolveSlackUsername(nothing, 'U3')).resolves.toBe('U3');
+        });
+
+        it('returns null when the API responds not ok', async () => {
+            const app = makeApp({ U1: { ok: false } });
+            await expect(resolveSlackUsername(app, 'U1')).resolves.toBeNull();
+        });
+
+        it('returns null when the API throws', async () => {
+            const app = makeApp({}); // any lookup throws
+            await expect(resolveSlackUsername(app, 'Uxxx')).resolves.toBeNull();
+        });
+    });
+
+    describe('resolveSlackUsernames', () => {
+        it('maps each resolvable member id and skips failures', async () => {
+            const app = makeApp({
+                U1: { ok: true, user: { profile: { display_name: 'One' } } },
+                U2: { ok: true, user: { profile: { display_name: 'Two' } } }
+                // U3 missing -> throws -> skipped
+            });
+
+            const result = await resolveSlackUsernames(app, ['U1', 'U2', 'U3']);
+
+            expect(result.get('U1')).toBe('One');
+            expect(result.get('U2')).toBe('Two');
+            expect(result.has('U3')).toBe(false);
+        });
+    });
+
+    describe('updateAllPlayerSlackNames', () => {
+        it('updates only players whose name changed and returns the count', async () => {
+            const app = makeApp({
+                U1: { ok: true, user: { profile: { display_name: 'NewName' } } },
+                U2: { ok: true, user: { profile: { display_name: 'Same' } } }
+            });
+            const datastore = {
+                getAllPlayers: jest.fn().mockResolvedValue([
+                    { sleeperId: 's1', slackMemberId: 'U1', slackName: 'OldName' }, // changes
+                    { sleeperId: 's2', slackMemberId: 'U2', slackName: 'Same' },    // unchanged
+                    { sleeperId: 's3', slackMemberId: 'bad', slackName: 'x' }       // filtered out (no 'U')
+                ]),
+                updatePlayerSlackName: jest.fn().mockResolvedValue()
+            };
+
+            const count = await updateAllPlayerSlackNames(app, datastore);
+
+            expect(count).toBe(1);
+            expect(datastore.updatePlayerSlackName).toHaveBeenCalledTimes(1);
+            expect(datastore.updatePlayerSlackName).toHaveBeenCalledWith('s1', 'NewName');
+        });
+
+        it('returns 0 when there are no valid member IDs', async () => {
+            const app = makeApp({});
+            const datastore = {
+                getAllPlayers: jest.fn().mockResolvedValue([{ sleeperId: 's1', slackMemberId: null }]),
+                updatePlayerSlackName: jest.fn()
+            };
+
+            const count = await updateAllPlayerSlackNames(app, datastore);
+
+            expect(count).toBe(0);
+            expect(datastore.updatePlayerSlackName).not.toHaveBeenCalled();
+        });
+
+        it('propagates datastore errors', async () => {
+            const app = makeApp({});
+            const datastore = {
+                getAllPlayers: jest.fn().mockRejectedValue(new Error('db down')),
+                updatePlayerSlackName: jest.fn()
+            };
+
+            await expect(updateAllPlayerSlackNames(app, datastore)).rejects.toThrow('db down');
+        });
+    });
+});

--- a/__tests__/shared/commandPatterns.test.js
+++ b/__tests__/shared/commandPatterns.test.js
@@ -1,0 +1,107 @@
+// Mock every handler module so we can assert the routing logic in isolation.
+jest.mock('../../handlers/lastpick.js', () => ({ handleLastPickCommand: jest.fn() }));
+jest.mock('../../handlers/registerDraft.js', () => ({ handleRegisterDraftCommand: jest.fn() }));
+jest.mock('../../handlers/registerPlayer.js', () => ({ handleRegisterPlayerCommand: jest.fn() }));
+jest.mock('../../handlers/registerLeague.js', () => ({ handleRegisterLeagueCommand: jest.fn() }));
+jest.mock('../../handlers/handleUsageCommand.js', () => ({ handleUsageCommand: jest.fn() }));
+jest.mock('../../handlers/unregisterDraft.js', () => ({ handleUnregisterDraftCommand: jest.fn() }));
+jest.mock('../../handlers/listDrafts.js', () => ({ handleListDraftsCommand: jest.fn() }));
+jest.mock('../../handlers/listLeagues.js', () => ({ handleListLeaguesCommand: jest.fn() }));
+jest.mock('../../handlers/updatePlayers.js', () => ({ handleUpdatePlayersCommand: jest.fn() }));
+jest.mock('../../handlers/checkRosters.js', () => ({
+    handleCheckRostersCommand: jest.fn(),
+    handleCheckLeagueRostersCommand: jest.fn()
+}));
+jest.mock('../../handlers/cacheManagement.js', () => ({
+    handleCacheStatusCommand: jest.fn(),
+    handleCacheRefreshCommand: jest.fn()
+}));
+
+const { createCommandPayload, handleAppMention, handleDirectMessage } = require('../../shared/commandPatterns.js');
+const { handleLastPickCommand } = require('../../handlers/lastpick.js');
+const { handleRegisterDraftCommand } = require('../../handlers/registerDraft.js');
+const { handleUsageCommand } = require('../../handlers/handleUsageCommand.js');
+const { handleCheckLeagueRostersCommand } = require('../../handlers/checkRosters.js');
+const { handleListDraftsCommand } = require('../../handlers/listDrafts.js');
+const { handleUpdatePlayersCommand } = require('../../handlers/updatePlayers.js');
+
+describe('commandPatterns', () => {
+    let say;
+    let logger;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        say = jest.fn().mockResolvedValue();
+        logger = { error: jest.fn() };
+    });
+
+    describe('createCommandPayload', () => {
+        it('builds a consistent payload', () => {
+            expect(createCommandPayload('hi', 'C1', '123.45')).toEqual({
+                text: 'hi', channel_id: 'C1', ts: '123.45'
+            });
+        });
+
+        it('defaults ts to null', () => {
+            expect(createCommandPayload('hi', 'C1').ts).toBeNull();
+        });
+    });
+
+    describe('handleAppMention routing', () => {
+        const mention = (text) => ({ event: { text: `<@U0BOT> ${text}`, channel: 'C1', ts: '99.9' }, say, logger, client: {} });
+
+        it('routes "last pick" to the last-pick handler', async () => {
+            await handleAppMention(mention('last pick'));
+            expect(handleLastPickCommand).toHaveBeenCalled();
+        });
+
+        it('routes "register draft 123" with the trimmed remaining text', async () => {
+            await handleAppMention(mention('register draft 123'));
+            expect(handleRegisterDraftCommand).toHaveBeenCalledWith(
+                expect.objectContaining({ command: expect.objectContaining({ text: '123' }) })
+            );
+        });
+
+        it('routes "check league rosters 555" to the league-rosters handler', async () => {
+            await handleAppMention(mention('check league rosters 555'));
+            expect(handleCheckLeagueRostersCommand).toHaveBeenCalledWith(
+                expect.objectContaining({ command: expect.objectContaining({ text: '555' }) })
+            );
+        });
+
+        it('shows usage when the mention has no command text', async () => {
+            await handleAppMention(mention(''));
+            expect(handleUsageCommand).toHaveBeenCalled();
+        });
+
+        it('replies with an error and usage for an unknown command', async () => {
+            await handleAppMention(mention('flibbertigibbet'));
+            expect(say).toHaveBeenCalledWith(expect.stringContaining("don't understand"));
+            expect(handleUsageCommand).toHaveBeenCalled();
+        });
+
+        it('logs and reports an error when a handler throws', async () => {
+            handleLastPickCommand.mockRejectedValueOnce(new Error('boom'));
+            await handleAppMention(mention('last pick'));
+            expect(logger.error).toHaveBeenCalled();
+            expect(say).toHaveBeenCalledWith(expect.stringContaining('error occurred'));
+        });
+    });
+
+    describe('handleDirectMessage', () => {
+        it('routes "list drafts" in a DM', async () => {
+            await handleDirectMessage({ message: { channel_type: 'im', text: 'list drafts', channel: 'D1' }, say, logger, client: {} });
+            expect(handleListDraftsCommand).toHaveBeenCalled();
+        });
+
+        it('routes "update players" in a DM', async () => {
+            await handleDirectMessage({ message: { channel_type: 'im', text: 'update players', channel: 'D1' }, say, logger, client: {} });
+            expect(handleUpdatePlayersCommand).toHaveBeenCalled();
+        });
+
+        it('ignores messages outside of a DM', async () => {
+            await handleDirectMessage({ message: { channel_type: 'channel', text: 'list drafts' }, say, logger, client: {} });
+            expect(handleListDraftsCommand).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/__tests__/shared/inputValidation.test.js
+++ b/__tests__/shared/inputValidation.test.js
@@ -1,0 +1,92 @@
+const {
+    parseSlackUserInput,
+    validateCommandArgs,
+    parseDraftId,
+    parseLeagueId
+} = require('../../shared/inputValidation.js');
+
+describe('inputValidation', () => {
+    describe('parseSlackUserInput', () => {
+        it('parses a plain Slack mention', () => {
+            const result = parseSlackUserInput('<@U1234567890>');
+            expect(result).toEqual({
+                memberId: 'U1234567890',
+                isValidMemberId: true,
+                originalInput: '<@U1234567890>'
+            });
+        });
+
+        it('parses a Slack mention that includes a username', () => {
+            const result = parseSlackUserInput('<@U1234567890|alice>');
+            expect(result.memberId).toBe('U1234567890');
+            expect(result.isValidMemberId).toBe(true);
+        });
+
+        it('accepts a bare 11-character member ID', () => {
+            const result = parseSlackUserInput('U1234567890');
+            expect(result.memberId).toBe('U1234567890');
+            expect(result.isValidMemberId).toBe(true);
+        });
+
+        it('treats anything else as a username', () => {
+            const result = parseSlackUserInput('alice');
+            expect(result).toEqual({
+                memberId: 'alice',
+                isValidMemberId: false,
+                originalInput: 'alice'
+            });
+        });
+
+        it('does not accept a malformed member ID as valid', () => {
+            const result = parseSlackUserInput('U123'); // too short
+            expect(result.isValidMemberId).toBe(false);
+        });
+    });
+
+    describe('validateCommandArgs', () => {
+        it('flags too few arguments with a usage message', () => {
+            const result = validateCommandArgs(['one'], 2, 'cmd a b');
+            expect(result.isValid).toBe(false);
+            expect(result.errorMessage).toContain('cmd a b');
+        });
+
+        it('passes when enough arguments are provided', () => {
+            expect(validateCommandArgs(['a', 'b'], 2, 'cmd a b')).toEqual({ isValid: true });
+        });
+    });
+
+    describe('parseDraftId', () => {
+        it('rejects empty input', () => {
+            const result = parseDraftId('   ');
+            expect(result.isValid).toBe(false);
+            expect(result.errorMessage).toMatch(/Draft ID/i);
+        });
+
+        it('rejects non-numeric input', () => {
+            const result = parseDraftId('abc123');
+            expect(result.isValid).toBe(false);
+            expect(result.errorMessage).toMatch(/numeric/i);
+        });
+
+        it('accepts and trims a numeric draft ID', () => {
+            const result = parseDraftId('  987654321  ');
+            expect(result).toEqual({ isValid: true, draftId: '987654321' });
+        });
+    });
+
+    describe('parseLeagueId', () => {
+        it('rejects empty input', () => {
+            expect(parseLeagueId('').isValid).toBe(false);
+        });
+
+        it('rejects non-numeric input', () => {
+            const result = parseLeagueId('league-1');
+            expect(result.isValid).toBe(false);
+            expect(result.errorMessage).toMatch(/numeric/i);
+        });
+
+        it('accepts and trims a numeric league ID', () => {
+            expect(parseLeagueId(' 123456 ')).toEqual({ isValid: true, leagueId: '123456' });
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -6,11 +6,25 @@
   "scripts": {
     "start:local": "node app.js",
     "start:sam": "sam local start-api --port 3000 --env-vars local-env.json",
-    "test": "jest",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch",
     "build": "npm ci --production"
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "handlers/**/*.js",
+      "services/**/*.js",
+      "shared/**/*.js"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 68,
+        "branches": 58,
+        "functions": 63,
+        "lines": 68
+      }
+    }
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Fourth PR of the architecture hardening plan (docs/ARCHITECTURE_PLAN.md) — the test-coverage half. Backfills the lowest-coverage, highest-value modules with fast, fully-mocked tests, and adds a CI coverage floor so it can't silently regress.

## New / expanded tests (+44 tests, 101 → 145)
- **`shared/inputValidation.js` 27% → 100%** — mention / member-id / username parsing, draft & league id validation, arg validation.
- **`services/slackUtils.js` 2% → ~96%** — username resolution with display/real/handle/id fallbacks, batch resolution (skips failures), bulk update with change-detection and error propagation.
- **`shared/commandPatterns.js` 0% → ~73%** — app-mention routing to each handler, the unknown-command and empty-mention paths, handler-error handling, and DM routing. (This is the bot's command-routing brain — was entirely untested.)
- **`services/datastore.js` 41% → ~66%** — league CRUD, `getAllChannelsWithLeagues` grouping, player updates, and the NFL cache get/**expiry** branches.

## CI ratchet (`package.json`)
- `npm test` now runs with `--coverage` and a global `coverageThreshold` (statements/lines **68**, functions **63**, branches **58**) — set just below current so it's a floor, not a cliff. Also fixes the previously-empty `coverage/` CI artifact.
- Added `npm run test:watch` for local dev (coverage off).

## Runtime alignment (workflows)
- CI test matrix **18/20 → 20/22**, and deploy build Node **20 → 22**, to match `package.json` engines (`>=22`) and the deployed `nodejs22.x` runtime. (Node 18 is EOL.)

## Result
Overall coverage **~54% (start of this whole effort) → ~70%**. Full suite 145 passing on Node 20 and 22.

## Not included (tracked, deliberately deferred)
The observability half of Phase 4 — CloudWatch alarms on Lambda errors (the draft monitor still fails silently) and a structured-log helper — is a separate change and will be its own PR. The `npm audit` fail-on-high CI gate stays deferred until the dependency upgrade (it's coupled to the bolt v3 / aws-sdk bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)