### PR TITLE
Phase 4b: error alarms + structured logging

### DIFF
--- a/__tests__/shared/logger.test.js
+++ b/__tests__/shared/logger.test.js
@@ -1,0 +1,51 @@
+const logger = require('../../shared/logger.js');
+
+describe('logger', () => {
+    let logSpy;
+    let warnSpy;
+    let errorSpy;
+
+    beforeEach(() => {
+        logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const lastJson = (spy) => JSON.parse(spy.mock.calls[spy.mock.calls.length - 1][0]);
+
+    it('emits a single-line JSON object with level, message and timestamp', () => {
+        logger.info('hello', { foo: 'bar' });
+
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const entry = lastJson(logSpy);
+        expect(entry).toMatchObject({ level: 'info', message: 'hello', foo: 'bar' });
+        expect(entry.timestamp).toEqual(expect.any(String));
+    });
+
+    it('routes levels to the matching console method', () => {
+        logger.warn('careful');
+        logger.error('broken');
+
+        expect(lastJson(warnSpy).level).toBe('warn');
+        expect(lastJson(errorSpy).level).toBe('error');
+    });
+
+    it('serializes Error objects in context to message + stack', () => {
+        const err = new Error('kaboom');
+        logger.error('failed', { error: err, draftId: '123' });
+
+        const entry = lastJson(errorSpy);
+        expect(entry.draftId).toBe('123');
+        expect(entry.error.message).toBe('kaboom');
+        expect(entry.error.stack).toContain('kaboom');
+    });
+
+    it('works with no context argument', () => {
+        expect(() => logger.debug('just a message')).not.toThrow();
+        expect(lastJson(logSpy).message).toBe('just a message');
+    });
+});

--- a/lambda-draft-monitor.js
+++ b/lambda-draft-monitor.js
@@ -1,5 +1,6 @@
 const { App } = require('@slack/bolt');
 const { checkDraftForUpdates } = require('./services/draftMonitor.js');
+const logger = require('./shared/logger.js');
 
 // Initialize the app for sending messages
 const app = new App({
@@ -28,8 +29,8 @@ exports.handler = async (event, context) => {
       })
     };
   } catch (error) {
-    console.error('Draft monitoring failed:', error);
-    
+    logger.error('Draft monitoring failed', { error });
+
     return {
       statusCode: 500,
       body: JSON.stringify({

--- a/services/draftMonitor.js
+++ b/services/draftMonitor.js
@@ -1,6 +1,7 @@
 const { getDraftPicks, getDraft } = require('./sleeper.js');
 const { generatePickMessagePayload } = require('../handlers/lastpick.js');
 const { getData, saveDraft } = require('./datastore.js');
+const logger = require('../shared/logger.js');
 
 
 /**
@@ -13,7 +14,7 @@ async function checkDraftForUpdates(app) {
     try {
         data = await getData();
     } catch (error) {
-        console.error("Draft Monitor: Could not read data.json.", error);
+        logger.error('Draft monitor: could not read registered drafts', { error });
         return;
     }
 
@@ -61,7 +62,7 @@ async function checkDraftForUpdates(app) {
                 });
             }
         } catch (error) {
-            console.error(`Draft Monitor: Error checking draft ${draftId}.`, error);
+            logger.error('Draft monitor: error checking draft', { draftId, error });
         }
     }));
 

--- a/shared/logger.js
+++ b/shared/logger.js
@@ -1,0 +1,39 @@
+/**
+ * Lightweight structured logger.
+ *
+ * Emits one JSON object per line so CloudWatch Logs Insights can filter and
+ * aggregate by level/field. Use instead of bare console.* for anything worth
+ * querying or alarming on. Error objects passed as `context.error` are
+ * serialized to { message, stack } (JSON.stringify drops Error fields otherwise).
+ */
+
+const LEVEL_METHOD = {
+    error: 'error',
+    warn: 'warn',
+    info: 'log',
+    debug: 'log'
+};
+
+function emit(level, message, context = {}) {
+    const ctx = { ...context };
+    if (ctx.error instanceof Error) {
+        ctx.error = { message: ctx.error.message, stack: ctx.error.stack };
+    }
+
+    const entry = {
+        level,
+        message,
+        ...ctx,
+        timestamp: new Date().toISOString()
+    };
+
+    const method = LEVEL_METHOD[level] || 'log';
+    console[method](JSON.stringify(entry));
+}
+
+module.exports = {
+    info: (message, context) => emit('info', message, context),
+    warn: (message, context) => emit('warn', message, context),
+    error: (message, context) => emit('error', message, context),
+    debug: (message, context) => emit('debug', message, context)
+};

--- a/template.yaml
+++ b/template.yaml
@@ -19,6 +19,14 @@ Parameters:
     AllowedValues: [dev, staging, prod]
     Description: Environment name
 
+  AlarmEmail:
+    Type: String
+    Default: ''
+    Description: Optional email address to subscribe to Lambda error alarms (leave blank to skip)
+
+Conditions:
+  HasAlarmEmail: !Not [!Equals [!Ref AlarmEmail, '']]
+
 Globals:
   Function:
     Runtime: nodejs22.x
@@ -289,6 +297,80 @@ Resources:
           ]
         }
 
+  # SNS topic for operational alarms
+  AlarmTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub 'ukff-alarms-${Environment}'
+      DisplayName: 'UKFFBot Alarms'
+
+  # Optional email subscription (only created when AlarmEmail is provided)
+  AlarmEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasAlarmEmail
+    Properties:
+      TopicArn: !Ref AlarmTopic
+      Protocol: email
+      Endpoint: !Ref AlarmEmail
+
+  # Error alarms — surface Lambda failures that would otherwise only land in logs
+  SlackBotErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub 'ukff-slack-bot-errors-${Environment}'
+      AlarmDescription: 'Slack bot Lambda reported one or more errors'
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref SlackBotFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlarmTopic
+
+  DraftMonitorErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub 'ukff-draft-monitor-errors-${Environment}'
+      AlarmDescription: 'Draft monitor Lambda reported one or more errors'
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref DraftMonitorFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlarmTopic
+
+  RosterSchedulerErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub 'ukff-roster-scheduler-errors-${Environment}'
+      AlarmDescription: 'Roster scheduler Lambda reported one or more errors'
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref RosterSchedulerFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlarmTopic
+
 Outputs:
   SlackBotApiUrl:
     Description: 'API Gateway endpoint URL for Slack events'
@@ -319,3 +401,9 @@ Outputs:
     Value: !GetAtt RosterSchedulerFunction.Arn
     Export:
       Name: !Sub '${AWS::StackName}-RosterSchedulerFunctionArn'
+
+  AlarmTopicArn:
+    Description: 'SNS topic ARN for operational alarms (subscribe here if no AlarmEmail was set)'
+    Value: !Ref AlarmTopic
+    Export:
+      Name: !Sub '${AWS::StackName}-AlarmTopicArn'


### PR DESCRIPTION
Final piece of Phase 4 (docs/ARCHITECTURE_PLAN.md) — observability. The draft monitor and the other Lambdas previously failed into `console.error` only, so nobody was notified. This adds alerting and queryable logs.

## Alarms (`template.yaml`)
- **SNS topic** for operational alarms, with an **optional email subscription** gated on a new `AlarmEmail` parameter (blank by default → no subscription, so existing deploys are unaffected).
- **CloudWatch Errors alarms on all three Lambdas** (Slack bot, draft monitor, roster scheduler): `Sum >= 1` over 5 min, `TreatMissingData: notBreaching`.
- `AlarmTopicArn` output so the topic can be subscribed to manually if no email is set.

## Structured logging (`shared/logger.js`)
- Lightweight JSON logger (`info`/`warn`/`error`/`debug`) — one object per line for CloudWatch Logs Insights filtering/aggregation. Serializes `Error` objects in context to `{ message, stack }` (plain `JSON.stringify` drops them).
- Adopted at the **draft-monitor failure paths** (the silent-failure spots the plan called out) in `services/draftMonitor.js` and `lambda-draft-monitor.js`. Broader rollout can follow incrementally; I scoped it to the named gap to avoid churning every `console.*` (and the tests that spy on them).

## Tests
- New `logger.test.js` (levels → correct console method, JSON shape, Error serialization, no-context). Suite **145 → 149**.

## Deploy note
Pass `AlarmEmail=you@example.com` at deploy (or subscribe to the `AlarmTopicArn` output) to receive alerts; alarms fire to the topic either way. The new parameter is optional, so nothing breaks if it's omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)