### PR TITLE
ci: fix deploy smoke test (expected 401 marked as failure)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,12 +200,20 @@ jobs:
         run: |
           echo "🧪 Running smoke tests..."
           
-          # Test API Gateway endpoint
+          # Test API Gateway endpoint. The Slack endpoint requires a valid
+          # signature, so an unsigned request correctly returns 401/403 — that
+          # still proves the endpoint is alive. Only a connection failure (000)
+          # or a 5xx indicates a real problem.
           echo "Testing API Gateway endpoint: $API_URL"
-          curl -f -X POST "$API_URL" \
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL" \
             -H "Content-Type: application/json" \
-            -d '{"type":"url_verification","challenge":"test"}' \
-            || (echo "❌ API Gateway health check failed" && exit 1)
+            -d '{"type":"url_verification","challenge":"test"}')
+          echo "Endpoint returned HTTP $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "000" ] || [ "$HTTP_STATUS" -ge 500 ]; then
+            echo "❌ API Gateway health check failed (HTTP $HTTP_STATUS)"
+            exit 1
+          fi
+          echo "✅ API Gateway reachable (HTTP $HTTP_STATUS)"
           
           # Test DynamoDB table exists
           echo "Testing DynamoDB table: $TABLE_NAME"


### PR DESCRIPTION
## Problem
Every push-to-main deploy has been showing red, but the `sam deploy` step actually **succeeded** every time (`Successfully created/updated stack`). The failure was the post-deploy **smoke test**: it runs `curl -f` against the Slack events endpoint, which requires a valid Slack signature and therefore returns **401** for an unsigned request. `curl -f` turns that 401 into a non-zero exit → job fails.

## Fix
Capture the HTTP status instead of using `-f`. A 401/403 means the endpoint is alive and correctly rejecting unsigned requests, so only a connection failure (`000`) or a `5xx` is treated as a real failure.

## Note
This unblocks the *false* failures. The most recent deploy (Phase 4b) also had a **real** failure — the deploy IAM user lacks SNS/CloudWatch-alarm permissions, so the alarm topic couldn't be created and the stack rolled back. That's being handled separately by adding the IAM permissions; once those are in place, merging this gives a fully green deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)