### PR TITLE
ci: subscribe alarm email via AlarmEmail parameter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,9 +149,10 @@ jobs:
           ENVIRONMENT: ${{ needs.determine-environment.outputs.environment }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
+          ALARM_EMAIL: ${{ vars.ALARM_EMAIL }}
         run: |
           STACK_NAME="ukff-slack-bot-${ENVIRONMENT}"
-          
+
           sam deploy \
             --stack-name $STACK_NAME \
             --s3-bucket $S3_BUCKET \
@@ -161,6 +162,7 @@ jobs:
               SlackBotToken=$SLACK_BOT_TOKEN \
               SlackSigningSecret=$SLACK_SIGNING_SECRET \
               Environment=$ENVIRONMENT \
+              AlarmEmail=$ALARM_EMAIL \
             --no-fail-on-empty-changeset \
             --no-confirm-changeset \
             --tags \


### PR DESCRIPTION
Wires the `ALARM_EMAIL` GitHub Actions variable (set to the alarm recipient) into the `sam deploy` parameter-overrides as `AlarmEmail`. On deploy, CloudFormation creates the SNS email subscription (`AlarmEmailSubscription`, gated on `HasAlarmEmail`).

- Address is stored as a repo **variable**, not committed to the workflow file.
- If the variable is ever unset, `AlarmEmail` is blank and no subscription is created (safe default).

After this deploys, AWS sends a **subscription confirmation email** to the address — it must be confirmed (one click) before alerts are delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)