### PR TITLE
chore: drop dead CORS config + unhardcode manifest URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
     },
     "settings": {
         "event_subscriptions": {
-            "request_url": "https://ij73zmabnj.execute-api.us-east-1.amazonaws.com/prod/slack/events",
+            "request_url": "https://YOUR_API_GATEWAY_URL/slack/events",
             "bot_events": [
                 "app_home_opened",
                 "app_mention",
@@ -39,7 +39,7 @@
         },
         "interactivity": {
             "is_enabled": true,
-            "request_url": "https://ij73zmabnj.execute-api.us-east-1.amazonaws.com/prod/slack/events"
+            "request_url": "https://YOUR_API_GATEWAY_URL/slack/events"
         },
         "org_deploy_enabled": false,
         "socket_mode_enabled": false,

--- a/template.yaml
+++ b/template.yaml
@@ -199,10 +199,8 @@ Resources:
     Properties:
       Name: !Sub 'ukff-slack-bot-api-${Environment}'
       StageName: !Ref Environment
-      Cors:
-        AllowMethods: "'POST, OPTIONS'"
-        AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-        AllowOrigin: "'*'"
+      # No CORS: this is a server-to-server Slack webhook (signature-verified),
+      # not a browser-facing API, so CORS headers serve no purpose.
       EndpointConfiguration:
         Type: REGIONAL
       TracingEnabled: true


### PR DESCRIPTION
The last two items from the architecture plan — both minor config cleanups.

## API Gateway CORS (`template.yaml`)
Removed the `Cors` block (was `AllowOrigin: '*'`). This endpoint is a **server-to-server, signature-verified Slack webhook** — Slack POSTs from its servers, there's no browser client, and CORS is a browser mechanism. So the CORS config was dead weight; removing it is more correct than narrowing `*` to a fake origin. No functional change (Slack never sends preflight/Origin).

## Manifest URL (`manifest.json`)
Replaced the hardcoded prod API Gateway URL in both `event_subscriptions.request_url` and `interactivity.request_url` with a `https://YOUR_API_GATEWAY_URL/slack/events` placeholder. The real value is the stack's `SlackBotApiUrl` output (and whatever is set in the Slack app dashboard), so it no longer needs to be committed in the reference manifest.

## Notes
- Validated: `manifest.json` parses, `template.yaml` parses with no `Cors` property, and no `ij73zmabnj` references remain anywhere in the repo.
- The live Slack app config (request URLs in the Slack dashboard) is unaffected — this only changes the committed reference manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)