### PR TITLE
fix: derive team count from settings.teams, not draft_order length

### DIFF
--- a/handlers/lastpick.js
+++ b/handlers/lastpick.js
@@ -35,7 +35,9 @@ async function generatePickMessagePayload(draft, picks, data, notifyNextPicker =
   // --- Logic to determine the next picker ---
   let nextPickerMessage = "The draft is complete!";
   const picksMade = picks.length;
-  const totalTeams = Object.keys(draft.draft_order).length; // Number of teams in the draft
+  // Prefer settings.teams (always correct). draft_order only lists real users, so in
+  // a mock draft it holds just the single human, which breaks team-count math.
+  const totalTeams = draft.settings.teams || Object.keys(draft.draft_order).length;
   // Calculate the total number of picks based on rounds and teams
   const totalPicks = draft.settings.rounds * totalTeams;
   if (picksMade < totalPicks) {


### PR DESCRIPTION
## Problem

Pick alerts came out wrong when smoke-testing with a Sleeper draft: every pick rendered as `X.01` and "On The Clock" always said *The draft is complete!*

Root cause: `generatePickMessagePayload` computed the team count from `Object.keys(draft.draft_order).length`. But `draft_order` only maps **real user accounts** to slots, so its length equals the team count only when every slot is owned.

- Solo mock → `draft_order` has 1 entry (CPU teams absent), so `totalTeams = 1`.
- `((pick_no - 1) % 1) + 1` is always `1` → every pick shows `.01`.
- `totalPicks = rounds × 1` → `picksMade` exceeds it almost immediately → always "draft complete".
- A real league with an orphan/unowned team is off by one (subtler, but still wrong).

A fully-owned real league happens to have `draft_order.length === teams`, which is why production looked fine.

## Fix

Use `draft.settings.teams` (authoritative) as the team count, falling back to the `draft_order` length only if it's ever absent.

## Testing

- Logic verified against live Sleeper data for the affected draft (`teams: 10`, `draft_order` had 1 entry).
- Existing `__tests__/handlers/lastpick.test.js` uses `settings.teams: 2` with a 2-entry `draft_order`, so both sources agree and assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)